### PR TITLE
Only include sysmacros.h on linux

### DIFF
--- a/consoletype.c
+++ b/consoletype.c
@@ -13,7 +13,9 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#if defined(__linux__)
 #include <sys/sysmacros.h>
+#endif
 
 enum termtype {
 	IS_VT = 0,


### PR DESCRIPTION
sysmacros.h is only needed for major() which is only used within an `#if defined(__linux__)` block. So, this header is only needed on linux.

This resolves https://bugs.gentoo.org/751511